### PR TITLE
[Quick Sign] Fix previous button when navigating between pages

### DIFF
--- a/src/QuickSignPDF/QuickSignPDF.tsx
+++ b/src/QuickSignPDF/QuickSignPDF.tsx
@@ -187,7 +187,7 @@ const QuickSignPDF = (): JSX.Element => {
                     disabled={
                       isSigning ||
                       !pdf ||
-                      activePage >= (doc?.getPageCount() || 1)
+                      activePage > (doc?.getPageCount() || 1)
                     }
                     className={`h-10 self-end text-white px-3 py-2 rounded-md mx-2 ${
                       activePage <= 1 || isSigning


### PR DESCRIPTION
When a user is at the end of the pdf pages the previous button is set to disabled and the button doesn't work anymore this should be a small fix.