### PR TITLE
[CreatePhotosSlideshow]  Fix FFmpeg should be loaded only once

### DIFF
--- a/src/CreatePhotosSlideshow/CreatePhotosSlideshow.tsx
+++ b/src/CreatePhotosSlideshow/CreatePhotosSlideshow.tsx
@@ -87,7 +87,10 @@ const CreatePhotosSlideshow = (): JSX.Element => {
   const generateVideo = useCallback(async () => {
     if (orderedItems.length === 0 || isGenerating) return;
     setIsGenerating(true);
-    await ffmpeg.load();
+
+    if (!ffmpeg.isLoaded()) {
+      await ffmpeg.load();
+    }
 
     ffmpeg.setProgress(({ ratio }) => {
       setProgress(parseFloat((ratio * 100).toFixed(1)));


### PR DESCRIPTION
FFmpeg should only be loaded once in a web page. 

Issue :

- Upload new photo in slide show tool
- Render with ffmpeg
- Navigate into another tool
- Click on slide show tool again
- Upload new photos and render 

Current : 
It throws and error FFmpeg can't be loaded twice
Expected:
To only load FFmpeg once 